### PR TITLE
Add open placement option to Sylvester

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ the output so all squares remain visible.  Pass `--vector` to generate an SVG in
 precision.
 
 ```
-python -m basel.tools.render_stack [N] --algo NAME [--output FILE] \
-    [--renderer {cycle,gradient}] [--colors NUM]
+python -m tools.render_stack [N] --algo NAME [--output FILE] \
+    [--renderer {cycle,gradient}] [--colors NUM] [--open]
 ```
 
 Arguments:
@@ -32,6 +32,7 @@ Arguments:
 * `--renderer` – coloring method: `cycle` or `gradient` (default: `cycle`)
 * `--colors` – number of colors for the cycle renderer (default: `2`)
 * `--vector` – output an SVG vector image instead of PPM
+* `--open` – use open placement rules when supported (e.g. `sylvester`)
 
 Some algorithms accept extra flags that extend or modify their behavior.
 Consult the relevant specification for details.

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -69,4 +69,5 @@ extend above height 1. Squares can be colored using either a cycling palette or
 gradient from red to blue. Pass `--renderer gradient` for the gradient style or
 adjust the number of cycling colors with `--colors N`. Pass `--relaxed` when using
 the sylvester algorithm if you wish to enable the relaxed placement rules; otherwise
-strict support is used.
+strict support is used. The `--open` flag avoids blocks lining up exactly with the
+top or right edges of their supports.


### PR DESCRIPTION
## Summary
- allow calling Sylvester stack with `open_bounds` to avoid blocks lining up exactly with supports
- document the `--open` flag in the Sylvester specification

## Testing
- `python algorithms/sylvester.py --help`
- `python algorithms/sylvester.py 10`
- `python algorithms/sylvester.py 10 --open`

------
https://chatgpt.com/codex/tasks/task_e_6865bc936fe0832499d9dac9262aa3aa