### PR TITLE
Fix odd placement in rational algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ geometry difficult to analyze.
 Finally the **Rational** algorithm reorganizes the placements to produce edges
 whose nontrivial vertices have rational coordinates.  Whenever an $n$‑square is
 placed, the next even‑numbered square $2n$ is positioned adjacent to it in the
-same direction.  Remaining odd squares fill the unused corners in order from bottom right
-to top left.  Infinite paths that repeat the same direction generate series of
-the form $\tfrac1n + \tfrac1{2n} + \tfrac1{4n} + \cdots = \tfrac2n$, ensuring every such vertex is
+same direction, while the square $2n+1$ is positioned in the opposite
+direction.  Each round therefore expands every square into two children.  Infinite paths that
+repeat the same direction generate series of the form $\tfrac1n + \tfrac1{2n} + \tfrac1{4n} + \cdots = \tfrac2n$, ensuring every such vertex is
 rational.  This result is still under investigation.
 
 ### Examples

--- a/algorithms/rational.py
+++ b/algorithms/rational.py
@@ -33,7 +33,6 @@ class Stack:
         self._map[2] = b2
         self._map[3] = b3
         self._current_round: List[int] = [2, 3]
-        self._next_odd = 5
 
     def _add_block(self, n: int, x: Fraction, y: Fraction, direction: str, parent: int) -> None:
         block = Block(n, Fraction(1, n), x, y, direction, parent)
@@ -45,43 +44,30 @@ class Stack:
             return
         while max(self._map) < count:
             next_round: List[int] = []
-            # doubling stage
-            for n in self._current_round:
-                child = 2 * n
-                b = self._map[n]
-                if b.direction == "right":
-                    x = b.x + b.side
-                    y = b.y
-                    orient = "right"
-                else:
-                    x = b.x
-                    y = b.y + b.side
-                    orient = "up"
-                if child <= count:
-                    self._add_block(child, x, y, orient, n)
-                    next_round.append(child)
-            # gather gaps for filling stage
-            gaps = []
             for n in self._current_round:
                 b = self._map[n]
+                even = 2 * n
+                odd = even + 1
                 if b.direction == "right":
-                    x = b.x
-                    y = b.y + b.side
-                    orient = "up"
+                    x_even = b.x + b.side
+                    y_even = b.y
+                    orient_even = "right"
+                    x_odd = b.x
+                    y_odd = b.y + b.side
+                    orient_odd = "up"
                 else:
-                    x = b.x + b.side
-                    y = b.y
-                    orient = "right"
-                gaps.append((y, -x, n, orient))
-            gaps.sort()
-            for y, negx, parent, orient in gaps:
-                if self._next_odd > count:
-                    break
-                x = -negx
-                n = self._next_odd
-                self._next_odd += 2
-                self._add_block(n, x, y, orient, parent)
-                next_round.append(n)
+                    x_even = b.x
+                    y_even = b.y + b.side
+                    orient_even = "up"
+                    x_odd = b.x + b.side
+                    y_odd = b.y
+                    orient_odd = "right"
+                if even <= count:
+                    self._add_block(even, x_even, y_even, orient_even, n)
+                    next_round.append(even)
+                if odd <= count:
+                    self._add_block(odd, x_odd, y_odd, orient_odd, n)
+                    next_round.append(odd)
             self._current_round = next_round
 
     def summary(self) -> str:

--- a/docs/specs/rational_stack.md
+++ b/docs/specs/rational_stack.md
@@ -14,17 +14,15 @@ direction stays the same.
    1‑square.  These two squares establish the initial directions
    (*right* for the 2‑square and *up* for the 3‑square).
 3. Afterwards proceed in rounds.  Suppose round `k` positioned a
-   collection of squares labelled `n_1, n_2, ...`.  Round `k+1` consists
-   of two stages:
-   - **Doubling stage.**  For each square `n_i` placed in round `k`,
-     position the square labelled `2 n_i` adjacent to `n_i` in the same
-     direction (`right` or `up`) that `n_i` occupies relative to its
-     own parent.
-   - **Filling stage.**  Numerous corner gaps remain from round `k` that
-     were not occupied by a doubled square.  Order these gaps from the
-     bottom rightmost one to the top leftmost.  Into them place the
-     smallest unused odd numbers in increasing order.  Each square fits
-     snugly against the squares that form its corner.
+   collection of squares labelled `n_1, n_2, ...`.  For each square
+   `n_i` placed in round `k`:
+   - Position the square labelled `2 n_i` adjacent to `n_i` in the same
+     direction (`right` or `up`) that `n_i` occupies relative to its own
+     parent.
+   - Position the square labelled `2 n_i + 1` adjacent to `n_i` in the
+     *other* direction (the direction not taken by `n_i` with respect to
+     its parent).
+   The squares placed this way make up round `k+1`.
 A square's direction (*right* or *up*) is recorded when it is placed and
 is inherited by its doubled successor in the following round.  If the
 same direction repeats indefinitely along some path, the sequence of


### PR DESCRIPTION
## Summary
- modify rational algorithm to place `2n` and `2n+1` adjacent to the same parent
- update rational stack specification with new procedure
- document new rule for rational algorithm in README

## Testing
- `python -m py_compile algorithms/*.py tools/*.py`
- `python -m tools.render_stack 10 --algo rational --vector --output test.svg`

------
https://chatgpt.com/codex/tasks/task_e_6866bead33188324a393b680e6156cdf