### PR TITLE
Update rendering defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ shapes for further exploration.  Individual implementations live in
 `algorithms/` with corresponding specifications under `docs/specs/`.
 
 The helper script `tools/render_stack.py` visualizes any of the algorithms. It
-produces a PPM image of the first *N* squares by default and automatically scales
-the output so all squares remain visible.  Pass `--vector` to generate an SVG instead for unlimited zooming
-precision.
+produces an SVG vector image of the first *N* squares by default and
+automatically scales the output so all squares remain visible. Pass `--binary`
+to generate a PPM bitmap instead for simple pixel graphics.
 
 ```
 python -m tools.render_stack [N] --algo NAME [--output FILE] \
-    [--renderer {cycle,gradient}] [--colors NUM] [--numbers]
+    [--coloring {cycle,gradient}] [--colors NUM] [--no-numbers] [--binary]
 ```
 
 Arguments:
 
 * `N` – number of squares to render (default: `100`)
 * `--algo` – algorithm to use (default: `rational`)
-* `--output` – name of the generated image file (default: `stack.ppm` or
-  `stack.svg` when `--vector` is used)
-* `--renderer` – coloring method: `cycle` or `gradient` (default: `cycle`)
+* `--output` – name of the generated image file (default: `stack.svg` or
+  `stack.ppm` when `--binary` is used)
+* `--coloring` – coloring method: `cycle` or `gradient` (default: `cycle`)
 * `--colors` – number of colors for the cycle renderer (default: `2`)
-* `--vector` – output an SVG vector image instead of PPM
-* `--numbers` – draw block numbers on the squares
+* `--binary` – output a PPM image instead of SVG
+* `--no-numbers` – omit block numbers on the squares
 
 Some algorithms accept extra flags that extend or modify their behavior.
 Consult the relevant specification for details.
@@ -81,7 +81,7 @@ rational.
 Render 50 squares using the gradient coloring:
 
 ```
-python -m tools.render_stack 50 --renderer gradient
+python -m tools.render_stack 50 --coloring gradient
 ```
 
 Render 20 squares cycling through 5 colors:
@@ -90,14 +90,14 @@ Render 20 squares cycling through 5 colors:
 python -m tools.render_stack 20 --colors 5
 ```
 
-Render blocks labeled with their numbers:
+Render blocks without numbers:
 
 ```
-python -m basel.tools.render_stack 10 --numbers
+python -m basel.tools.render_stack 10 --no-numbers
 ```
 
-Generate a vector image instead of a PPM:
+Generate a PPM image instead of a vector SVG:
 
 ```
-python -m tools.render_stack 20 --vector
+python -m tools.render_stack 20 --binary
 ```

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -62,11 +62,12 @@ type so that every coordinate and interval length is represented exactly as a
 rational number.
 
 A companion script (`tools/render_stack.py`) renders the first N squares as an
-image file. Run `python -m tools.render_stack` to generate `stack.ppm` by
-default. Refer to the project README for additional output options.
+image file. Run `python -m tools.render_stack` to generate `stack.svg` by
+default. Pass `--binary` to obtain `stack.ppm` instead. Refer to the project
+README for additional output options.
 The renderer automatically scales its output to display all squares, even when
 they extend above height 1. Squares can be colored using either a cycling
-palette or a gradient from red to blue. Pass `--renderer gradient` for the
+palette or a gradient from red to blue. Pass `--coloring gradient` for the
 gradient style or adjust the number of cycling colors with `--colors N`. By
 default the Sylvester algorithm leaves a small gap above each block. Use
 `--fill` to pack blocks flush against their supports or `--fill-with-seams` to

--- a/tools/render_stack.py
+++ b/tools/render_stack.py
@@ -296,7 +296,7 @@ def main() -> None:
         help="allow seams in the packed sylvester variant",
     )
     parser.add_argument(
-        "--renderer",
+        "--coloring",
         choices=["cycle", "gradient"],
         default="cycle",
         help="coloring method",
@@ -308,14 +308,14 @@ def main() -> None:
         help="number of colors to cycle through (for cycle renderer)",
     )
     parser.add_argument(
-        "--numbers",
+        "--no-numbers",
         action="store_true",
-        help="draw block numbers on the squares",
+        help="omit block numbers on the squares",
     )
     parser.add_argument(
-        "--vector",
+        "--binary",
         action="store_true",
-        help="write an SVG vector image instead of a PPM file",
+        help="write a PPM bitmap image instead of an SVG file",
     )
     parser.add_argument("--output", help="output file name")
     args = parser.parse_args()
@@ -333,22 +333,22 @@ def main() -> None:
         stack = load_stack(args.algo, strict=True, open_bounds=False)
     stack.build(args.N)
     if args.output is None:
-        args.output = "stack.svg" if args.vector else "stack.ppm"
-    if args.vector:
-        render_svg(
-            stack,
-            filename=args.output,
-            renderer=args.renderer,
-            colors=args.colors,
-            numbers=args.numbers,
-        )
-    else:
+        args.output = "stack.ppm" if args.binary else "stack.svg"
+    if args.binary:
         render_ppm(
             stack,
             filename=args.output,
-            renderer=args.renderer,
+            renderer=args.coloring,
             colors=args.colors,
-            numbers=args.numbers,
+            numbers=not args.no_numbers,
+        )
+    else:
+        render_svg(
+            stack,
+            filename=args.output,
+            renderer=args.coloring,
+            colors=args.colors,
+            numbers=not args.no_numbers,
         )
 
 


### PR DESCRIPTION
## Summary
- default to generating SVG images
- add `--binary` option for PPM output
- rename `--renderer` option to `--coloring`
- show numbers by default with `--no-numbers` to disable
- update docs for new flags

## Testing
- `python -m tools.render_stack -h`
- `python -m tools.render_stack 3 --output test.svg`
- `python -m tools.render_stack 3 --binary --output test.ppm`


------
https://chatgpt.com/codex/tasks/task_e_6866ca0ce3f083249d9dd9b9a19e17b9