### PR TITLE
Embed example images in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ $2, 3, 7, 43, 1807, \ldots$ except the 2nd term.  Each denominator after $6$ is 
 multiplying the previous one by the next integer (e.g., $1807 = 42 * 43$). The resulting shape
 resembles a fractal with endlessly finer wiggles.
 
+![Sylvester stack example](docs/images/sylvester.svg)
+
 Seeking a configuration with clearer structure, I next tried the **Erdos**
 algorithm.  Rest the $1$‑square against the ground and a wall to create two
 corners.  Place the $2$‑square in the lower corner and the $3$‑square above it.
@@ -68,6 +70,8 @@ $1 + \tfrac13 + \tfrac17 + \tfrac1{15} + \tfrac1{2^n-1} + \cdots$.  This
 irrational value and related series appear throughout the boundary, making the
 geometry difficult to analyze.
 
+![Erdos stack example](docs/images/erdos.svg)
+
 Finally the **Rational** algorithm reorganizes the placements to produce edges
 whose nontrivial vertices have rational coordinates.  Whenever an $n$‑square is
 placed, the next even‑numbered square $2n$ is positioned adjacent to it in the
@@ -75,6 +79,8 @@ same direction, while the square $2n+1$ is positioned in the opposite
 direction.  Each round therefore expands every square into two children.  Infinite paths that
 repeat the same direction generate series of the form $\tfrac1n + \tfrac1{2n} + \tfrac1{4n} + \cdots = \tfrac2n$, ensuring every such vertex is
 rational.
+
+![Rational stack example](docs/images/rational.svg)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,11 @@ Consult the relevant specification for details.
 
 The **Sylvester** algorithm was my starting point.  It drops each $n$‑square
 into a unit‑tall horizontal cavity using the simplest possible sliding rule.
-This process creates a boundary with infinitely many oscillations.  The boundary
-begins at $(S, 1)$ where
-
-$$S = 1 + \tfrac16 + \tfrac1{42} + \tfrac1{1806} + \cdots,$$
-
-and the denominators $1, 6, 42, 1806, \ldots$ are one less than each term of
-[Sylvester's sequence](https://en.wikipedia.org/wiki/Sylvester%27s_sequence)
-$2, 3, 7, 43, 1807, \ldots$ except the 2nd term.  Each denominator after $6$ is obtained by
-multiplying the previous one by the next integer (e.g., $1807 = 42 * 43$). The resulting shape
-resembles a fractal with endlessly finer wiggles.
+The packed variants appear to trace a boundary stretching from $(1,1)$ to
+$(0,S)$, where $S$ may diverge to infinity though this has not been proven.
+The squares immediately to the right of the 1 follow
+[Sylvester's sequence](https://en.wikipedia.org/wiki/Sylvester%27s_sequence),
+whose first few terms are $2, 3, 7, 43,$ and $1807$.
 
 ![Sylvester stack example](docs/images/sylvester.svg)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Arguments:
 * `--coloring` – coloring method: `cycle` or `gradient` (default: `cycle`)
 * `--colors` – number of colors for the cycle renderer (default: `2`)
 * `--binary` – output a PPM image instead of SVG
-* `--no-numbers` – omit block numbers on the squares
+* `--no-numbers` – omit square numbers on the squares
 
 Some algorithms accept extra flags that extend or modify their behavior.
 Consult the relevant specification for details.
@@ -96,7 +96,7 @@ Render 20 squares cycling through 5 colors:
 python -m tools.render_stack 20 --colors 5
 ```
 
-Render blocks without numbers:
+Render squares without numbers:
 
 ```
 python -m basel.tools.render_stack 10 --no-numbers

--- a/README.md
+++ b/README.md
@@ -44,12 +44,16 @@ Consult the relevant specification for details.
 - [`rational`](docs/specs/rational_stack.md) – doubles squares when direction repeats
 
 The **Sylvester** algorithm was my starting point.  It drops each $n$‑square
-into a unit‑tall horizontal cavity using the simplest possible sliding rule.
-The packed variants appear to trace a boundary stretching from $(1,1)$ to
-$(0,S)$, where $S$ may diverge to infinity though this has not been proven.
-The squares immediately to the right of the 1 follow
-[Sylvester's sequence](https://en.wikipedia.org/wiki/Sylvester%27s_sequence),
+into a unit‑tall horizontal cavity using the simplest possible sliding rule
+while never allowing a square to completely fill the remining space. As a result,
+the squares immediately to the right of the 1 follow [Sylvester's sequence](https://en.wikipedia.org/wiki/Sylvester%27s_sequence),
 whose first few terms are $2, 3, 7, 43,$ and $1807$.
+
+The variant appears to trace a boundary stretching from $(1,1)$ to
+$(0,S)$, where $S$ may diverge to infinity though this has not been proven. The
+boundary wiggles like a snake with progressively smaller fractal-like
+sub-wiggles as tall or wide stacks of similar sized squares fill narrow gaps
+between similarly sized larger squares.
 
 ![Sylvester stack example](docs/images/sylvester.svg)
 

--- a/algorithms/erdos.py
+++ b/algorithms/erdos.py
@@ -4,19 +4,19 @@ from fractions import Fraction
 from typing import List
 
 @dataclass
-class Block:
+class Square:
     n: int
     side: Fraction
     x: Fraction
     y: Fraction  # bottom coordinate
 
 class Stack:
-    """Construct the block stack using the Erdos method."""
+    """Construct the square stack using the Erdos method."""
 
     def __init__(self, strict: bool = True) -> None:
         # ``strict`` is accepted for API compatibility but ignored.
-        self.blocks: List[Block] = [
-            Block(1, Fraction(1), Fraction(0), Fraction(0))
+        self.squares: List[Square] = [
+            Square(1, Fraction(1), Fraction(0), Fraction(0))
         ]
 
     def _position(self, n: int) -> tuple[Fraction, Fraction]:
@@ -34,17 +34,17 @@ class Stack:
             prefix = prefix * 2 + int(b)
         return x, y
 
-    def add_block(self, n: int) -> None:
+    def add_square(self, n: int) -> None:
         x, y = self._position(n)
-        self.blocks.append(Block(n, Fraction(1, n), x, y))
+        self.squares.append(Square(n, Fraction(1, n), x, y))
 
     def build(self, count: int) -> None:
         for n in range(2, count + 1):
-            self.add_block(n)
+            self.add_square(n)
 
     def summary(self) -> str:
         lines = []
-        for b in self.blocks:
+        for b in self.squares:
             lines.append(
                 f"n={b.n}: left={b.x} bottom={b.y} side={b.side}"
             )

--- a/algorithms/rational.py
+++ b/algorithms/rational.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from typing import List, Dict, Optional
 
 @dataclass
-class Block:
+class Square:
     n: int
     side: Fraction
     x: Fraction
@@ -13,31 +13,31 @@ class Block:
     parent: Optional[int] = None
 
 class Stack:
-    """Construct blocks according to the rational stacking specification."""
+    """Construct squares according to the rational stacking specification."""
 
     def __init__(self, strict: bool = True) -> None:
         # ``strict`` is accepted for API compatibility but ignored.
-        self.blocks: List[Block] = []
-        self._map: Dict[int, Block] = {}
+        self.squares: List[Square] = []
+        self._map: Dict[int, Square] = {}
         self._init_seed()
 
     def _init_seed(self) -> None:
-        # create 1-block
-        b1 = Block(1, Fraction(1), Fraction(0), Fraction(0))
-        self.blocks.append(b1)
+        # create 1-square
+        b1 = Square(1, Fraction(1), Fraction(0), Fraction(0))
+        self.squares.append(b1)
         self._map[1] = b1
-        # place 2-block to the right and 3-block above
-        b2 = Block(2, Fraction(1, 2), Fraction(1), Fraction(0), "right", 1)
-        b3 = Block(3, Fraction(1, 3), Fraction(0), Fraction(1), "up", 1)
-        self.blocks.extend([b2, b3])
+        # place 2-square to the right and 3-square above
+        b2 = Square(2, Fraction(1, 2), Fraction(1), Fraction(0), "right", 1)
+        b3 = Square(3, Fraction(1, 3), Fraction(0), Fraction(1), "up", 1)
+        self.squares.extend([b2, b3])
         self._map[2] = b2
         self._map[3] = b3
         self._current_round: List[int] = [2, 3]
 
-    def _add_block(self, n: int, x: Fraction, y: Fraction, direction: str, parent: int) -> None:
-        block = Block(n, Fraction(1, n), x, y, direction, parent)
-        self.blocks.append(block)
-        self._map[n] = block
+    def _add_square(self, n: int, x: Fraction, y: Fraction, direction: str, parent: int) -> None:
+        square = Square(n, Fraction(1, n), x, y, direction, parent)
+        self.squares.append(square)
+        self._map[n] = square
 
     def build(self, count: int) -> None:
         if count <= 3:
@@ -63,16 +63,16 @@ class Stack:
                     y_odd = b.y
                     orient_odd = "right"
                 if even <= count:
-                    self._add_block(even, x_even, y_even, orient_even, n)
+                    self._add_square(even, x_even, y_even, orient_even, n)
                     next_round.append(even)
                 if odd <= count:
-                    self._add_block(odd, x_odd, y_odd, orient_odd, n)
+                    self._add_square(odd, x_odd, y_odd, orient_odd, n)
                     next_round.append(odd)
             self._current_round = next_round
 
     def summary(self) -> str:
         lines = []
-        for b in sorted(self.blocks, key=lambda b: b.n):
+        for b in sorted(self.squares, key=lambda b: b.n):
             lines.append(
                 f"n={b.n}: left={b.x} bottom={b.y} side={b.side}"
             )

--- a/algorithms/sylvester.py
+++ b/algorithms/sylvester.py
@@ -4,7 +4,7 @@ from fractions import Fraction
 from typing import List, Optional
 
 @dataclass
-class Block:
+class Square:
     n: int
     side: Fraction
     x: Fraction
@@ -21,7 +21,7 @@ class Corner:
 
 class Stack:
     """Corner-based Sylvester stack.  ``open_bounds=True`` leaves a small gap
-    above each block.  ``open_bounds=False`` packs blocks flush against their
+    above each square.  ``open_bounds=False`` packs squares flush against their
     supports."""
 
     def __init__(self, strict: bool = True, open_bounds: bool = True) -> None:
@@ -29,7 +29,7 @@ class Stack:
             raise NotImplementedError("Relaxed support not implemented")
         self.strict = True
         self.open_bounds = open_bounds
-        self.blocks: List[Block] = [Block(1, Fraction(1), Fraction(0), Fraction(0))]
+        self.squares: List[Square] = [Square(1, Fraction(1), Fraction(0), Fraction(0))]
         self.segments: List[tuple[Fraction, Fraction, Fraction]] = [
             (Fraction(0), Fraction(1), Fraction(1))
         ]
@@ -60,7 +60,7 @@ class Stack:
         new_segments.append((left, right, height))
         self.segments = new_segments
 
-    def add_block(self, n: int) -> None:
+    def add_square(self, n: int) -> None:
         side = Fraction(1, n)
         for i, c in enumerate(self.corners):
             if c.hspan is not None and side > c.hspan:
@@ -80,7 +80,7 @@ class Stack:
             raise RuntimeError("no position found")
         x = c.x
         bottom = c.bottom
-        self.blocks.append(Block(n, side, x, bottom))
+        self.squares.append(Square(n, side, x, bottom))
         self._insert_segment(x, x + side, bottom + side)
         self._merge()
         self.corners.pop(i)
@@ -117,11 +117,11 @@ class Stack:
 
     def build(self, count: int) -> None:
         for n in range(2, count + 1):
-            self.add_block(n)
+            self.add_square(n)
 
     def summary(self) -> str:
         lines = []
-        for b in self.blocks:
+        for b in self.squares:
             lines.append(f"n={b.n}: left={b.x} bottom={b.y} side={b.side}")
         return "\n".join(lines)
 
@@ -129,13 +129,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Simulate Sylvester block stacking (corner version)"
+        description="Simulate Sylvester square stacking (corner version)"
     )
-    parser.add_argument("N", type=int, nargs="?", default=10, help="number of blocks to simulate")
+    parser.add_argument("N", type=int, nargs="?", default=10, help="number of squares to simulate")
     parser.add_argument(
         "--fill",
         action="store_true",
-        help="pack blocks flush against their supports",
+        help="pack squares flush against their supports",
     )
     args = parser.parse_args()
 

--- a/algorithms/sylvester_with_seams.py
+++ b/algorithms/sylvester_with_seams.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 @dataclass
-class Block:
+class Square:
     n: int
     side: Fraction
     x: Fraction
@@ -14,7 +14,7 @@ class Stack:
     def __init__(self, strict: bool = True, open_bounds: bool = False):
         self.strict = strict
         self.open_bounds = open_bounds
-        self.blocks: List[Block] = [Block(1, Fraction(1), Fraction(0), Fraction(0))]
+        self.squares: List[Square] = [Square(1, Fraction(1), Fraction(0), Fraction(0))]
         self.segments: List[Tuple[Fraction, Fraction, Fraction]] = [
             (Fraction(0), Fraction(1), Fraction(1))
         ]
@@ -99,7 +99,7 @@ class Stack:
         intervals: List[Tuple[Fraction, Fraction]] = []
         if x == 0:
             intervals.append((Fraction(0), Fraction(1)))
-        for b in self.blocks:
+        for b in self.squares:
             if b.x + b.side == x:
                 intervals.append((b.y, b.y + b.side))
         intervals.sort()
@@ -149,7 +149,7 @@ class Stack:
         new_segments.append((left, right, height))
         self.segments = new_segments
 
-    def add_block(self, n: int):
+    def add_square(self, n: int):
         side = Fraction(1, n)
         x = Fraction(0)
         bottom = Fraction(1)
@@ -172,18 +172,18 @@ class Stack:
                 bottom = support
                 break
             x = next_x
-        self.blocks.append(Block(n, side, x, bottom))
+        self.squares.append(Square(n, side, x, bottom))
         # insert new segment and remove covered pieces of older segments
         self._insert_segment(x, x + side, bottom + side)
         self._merge()
 
     def build(self, count: int):
         for n in range(2, count + 1):
-            self.add_block(n)
+            self.add_square(n)
 
     def summary(self) -> str:
         lines = []
-        for b in self.blocks:
+        for b in self.squares:
             lines.append(
                 f"n={b.n}: left={b.x} bottom={b.y} side={b.side}"
             )
@@ -192,8 +192,8 @@ class Stack:
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Simulate Sylvester block stacking (with seams)")
-    parser.add_argument("N", type=int, nargs="?", default=10, help="number of blocks to simulate")
+    parser = argparse.ArgumentParser(description="Simulate Sylvester square stacking (with seams)")
+    parser.add_argument("N", type=int, nargs="?", default=10, help="number of squares to simulate")
     parser.add_argument("--fill-with-seams", action="store_true", help="dummy flag for compatibility")
     args = parser.parse_args()
 

--- a/docs/open_problems.md
+++ b/docs/open_problems.md
@@ -6,7 +6,7 @@ This document collects questions and answers that arise while studying the Sylve
 
 **Problem.**  As squares are stacked, what is the length of the portion of the top boundary that lies exactly on the horizontal line `y = 1`?
 
-**Answer.**  Several blocks ultimately come to rest with their top sides on the line `y = 1`.  The pattern begins with the 1-block occupying `[0,1]`.  Later, the 6-block sits atop the stack of the 2- and 3-blocks and contributes an additional segment of length `1/6`.  The 42-block rests on a stack involving the 7-block and contributes `1/42`, and so on.  These special block sizes are one less than the Sylvester numbers `2, 3, 7, 43, 1807, ...`.
+**Answer.**  Several squares ultimately come to rest with their top sides on the line `y = 1`.  The pattern begins with the 1-square occupying `[0,1]`.  Later, the 6-square sits atop the stack of the 2- and 3-squares and contributes an additional segment of length `1/6`.  The 42-square rests on a stack involving the 7-square and contributes `1/42`, and so on.  These special square sizes are one less than the Sylvester numbers `2, 3, 7, 43, 1807, ...`.
 
 The total length of the intersection is therefore
 
@@ -15,6 +15,6 @@ The total length of the intersection is therefore
 \]
 where `S_k` denotes the `k`‑th Sylvester number.  Determining the exact value of `\alpha` remains an open question, but the series converges quickly.
 
-## Does the 20-block align with the 4-block?
+## Does the 20-square align with the 4-square?
 
-Some hand calculations suggested the 20-block might come to rest with its top at the same height as the 4-block.  A simulation using exact rational arithmetic shows this is not the case.  The 4-block has top height `1/4`, while the 20-block ends with bottom height `35873/58140` and top height `1939/2907`.  Thus there is no matching height at block 20 in either the strict or relaxed variants.
+Some hand calculations suggested the 20-square might come to rest with its top at the same height as the 4-square.  A simulation using exact rational arithmetic shows this is not the case.  The 4-square has top height `1/4`, while the 20-square ends with bottom height `35873/58140` and top height `1939/2907`.  Thus there is no matching height at square 20 in either the strict or relaxed variants.

--- a/docs/specs/erdos_stack.md
+++ b/docs/specs/erdos_stack.md
@@ -21,6 +21,8 @@ is unrelated to the physical falling and sliding rules of the Sylvester stack bu
 produces a nested family of squares that can be rendered with the same
 visualization script.
 
+![Erdos stack example](../images/erdos.svg)
+
 A reference implementation lives in `algorithms/erdos.py`.  Use
 `tools/render_stack.py` with `--algo erdos` to visualize the first N
 squares.  The renderer scales automatically to include all squares.

--- a/docs/specs/rational_stack.md
+++ b/docs/specs/rational_stack.md
@@ -30,6 +30,8 @@ square sizes on that path is `1/n, 1/(2n), 1/(4n), ...`, which sums to
 `2/n`.  Consequently every jagged triangle on the boundary has
 rationally located vertices.
 
+![Rational stack example](../images/rational.svg)
+
 An implementation of this algorithm lives in
 `algorithms/rational.py`.  See the module for a concise reference
 version and the README for rendering instructions.

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -34,14 +34,13 @@ The distinction between these variants arises quite early in the
 construction.  Immediately to the right of the 2‑block the stack contains
 a 4‑block topped by a 5‑block, which in turn supports the 20‑block.
 Both configurations reach exactly height `1/2`, leaving a plateau split
-down the seam between the 2‑ and 20‑blocks.  We must therefore decide
-whether a later block may balance across that seam—allowed in the
-relaxed version but forbidden in the strict one.  It is not yet known
-whether this is the only such occurrence or if the pattern repeats
-finitely or infinitely many times.  Likewise, it remains unclear
-whether a vertical seam can arise from a row of blocks resting on a
-block of equal length and, if so, whether that happens only finitely
-often or infinitely many times.
+down the seam between the 2‑ and 20‑blocks.  In the relaxed version the
+21‑block can rest across that horizontal seam.  A vertical example occurs
+later when the 9‑ and 72‑blocks sit atop the 8‑block, extending just as
+far to the right as the 8‑block itself, so the 80‑block rests on the
+32‑block and covers the seam.  These cases confirm that both horizontal
+and vertical seams appear at least once, though it remains unknown
+whether they recur infinitely many times.
 
 ![Sylvester stack example](../images/sylvester.svg)
 
@@ -75,6 +74,19 @@ default the Sylvester algorithm leaves a small gap above each block. Use
 `--fill` to pack blocks flush against their supports or `--fill-with-seams` to
 allow seams in the packed version.
 
+### Filled Sylvester stack
+
+Notice the 6‑block sits on the 3‑block to completely fill the gap that the
+default algorithm leaves for the 7‑block and every later block in Sylvester's
+sequence.
+
 ![Filled Sylvester stack](../images/sylvester_fill.svg)
+
+### Filled with seams
+
+Notice the 4+5+20 blocks stack to the same height as the 2‑block, letting the
+21‑block rest on the seam they create.  Likewise the 9‑ and 72‑blocks on top of
+the 8‑block extend as far right as the 8‑block, so the 80‑block can sit on the
+32‑block and cover the seam.
 
 ![Filled with seams](../images/sylvester_fill_with_seams.svg)

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -24,21 +24,21 @@ statement. Each step adds an axis aligned square of side `1/n` for
    We consider two variants:
    
    - **Strict support** – both the bottom and left sides must touch a
-     single block or the ground/left boundary.
+     single square or the ground/left boundary.
    - **Relaxed support** – the bottom may rest on several squares as long
      as their top faces form a contiguous interval of equal height, and
      the left side may touch several squares whose right edges form a
      continuous vertical segment.
 
 The distinction between these variants arises quite early in the
-construction.  Immediately to the right of the 2‑block the stack contains
-a 4‑block topped by a 5‑block, which in turn supports the 20‑block.
+construction.  Immediately to the right of the 2‑square the stack contains
+a 4‑square topped by a 5‑square, which in turn supports the 20‑square.
 Both configurations reach exactly height `1/2`, leaving a plateau split
-down the seam between the 2‑ and 20‑blocks.  In the relaxed version the
-21‑block can rest across that horizontal seam.  A vertical example occurs
-later when the 9‑ and 72‑blocks sit atop the 8‑block, extending just as
-far to the right as the 8‑block itself, so the 80‑block rests on the
-32‑block and covers the seam.  These cases confirm that both horizontal
+down the seam between the 2‑ and 20‑squares.  In the relaxed version the
+21‑square can rest across that horizontal seam.  A vertical example occurs
+later when the 9‑ and 72‑squares sit atop the 8‑square, extending just as
+far to the right as the 8‑square itself, so the 80‑square rests on the
+32‑square and covers the seam.  These cases confirm that both horizontal
 and vertical seams appear at least once, though it remains unknown
 whether they recur infinitely many times.
 
@@ -70,23 +70,23 @@ The renderer automatically scales its output to display all squares, even when
 they extend above height 1. Squares can be colored using either a cycling
 palette or a gradient from red to blue. Pass `--coloring gradient` for the
 gradient style or adjust the number of cycling colors with `--colors N`. By
-default the Sylvester algorithm leaves a small gap above each block. Use
-`--fill` to pack blocks flush against their supports or `--fill-with-seams` to
+default the Sylvester algorithm leaves a small gap above each square. Use
+`--fill` to pack squares flush against their supports or `--fill-with-seams` to
 allow seams in the packed version.
 
 ### Filled Sylvester stack
 
-Notice the 6‑block sits on the 3‑block to completely fill the gap that the
-default algorithm leaves for the 7‑block and every later block in Sylvester's
+Notice the 6‑square sits on the 3‑square to completely fill the gap that the
+default algorithm leaves for the 7‑square and every later square in Sylvester's
 sequence.
 
 ![Filled Sylvester stack](../images/sylvester_fill.svg)
 
 ### Filled with seams
 
-Notice the 4+5+20 blocks stack to the same height as the 2‑block, letting the
-21‑block rest on the seam they create.  Likewise the 9‑ and 72‑blocks on top of
-the 8‑block extend as far right as the 8‑block, so the 80‑block can sit on the
-32‑block and cover the seam.
+Notice the 4+5+20 squares stack to the same height as the 2‑square, letting the
+21‑square rest on the seam they create.  Likewise the 9‑ and 72‑squares on top of
+the 8‑square extend as far right as the 8‑square, so the 80‑square can sit on the
+32‑square and cover the seam.
 
 ![Filled with seams](../images/sylvester_fill_with_seams.svg)

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -43,6 +43,8 @@ whether a vertical seam can arise from a row of blocks resting on a
 block of equal length and, if so, whether that happens only finitely
 often or infinitely many times.
 
+![Sylvester stack example](../images/sylvester.svg)
+
 The union of all placed squares forms a one unit tall shape of total area
 `\sum_{n=1}^\infty 1/n^2 = \pi^2/6`.
 
@@ -72,3 +74,7 @@ gradient style or adjust the number of cycling colors with `--colors N`. By
 default the Sylvester algorithm leaves a small gap above each block. Use
 `--fill` to pack blocks flush against their supports or `--fill-with-seams` to
 allow seams in the packed version.
+
+![Filled Sylvester stack](../images/sylvester_fill.svg)
+
+![Filled with seams](../images/sylvester_fill_with_seams.svg)

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -74,6 +74,18 @@ default the Sylvester algorithm leaves a small gap above each square. Use
 `--fill` to pack squares flush against their supports or `--fill-with-seams` to
 allow seams in the packed version.
 
+When squares are packed without gaps, the right edge develops a boundary with
+infinitely many oscillations.  The boundary begins at $(S, 1)$ where
+
+$$S = 1 + \tfrac16 + \tfrac1{42} + \tfrac1{1806} + \cdots,$$
+
+and the denominators $1, 6, 42, 1806, \ldots$ are one less than each term of
+[Sylvester's sequence](https://en.wikipedia.org/wiki/Sylvester%27s_sequence)
+$2, 3, 7, 43, 1807, \ldots$ except the 2nd term. Each denominator after $6$ is
+obtained by multiplying the previous one by the next integer (e.g.,
+$1807 = 42 * 43$). The resulting shape resembles a fractal with endlessly finer
+wiggles.
+
 ### Filled Sylvester stack
 
 Notice the 6‑square sits on the 3‑square to completely fill the gap that the

--- a/docs/specs/sylvester_stack.md
+++ b/docs/specs/sylvester_stack.md
@@ -86,6 +86,11 @@ obtained by multiplying the previous one by the next integer (e.g.,
 $1807 = 42 * 43$). The resulting shape resembles a fractal with endlessly finer
 wiggles.
 
+The fact that 2 is missing from this sequence that otherwise matches Sylvester's
+sequence is that led me to include the rule that newly placed blocks must be
+strictly smaller than the gap they fill. Below are two variations without that
+requirement.
+
 ### Filled Sylvester stack
 
 Notice the 6‑square sits on the 3‑square to completely fill the gap that the

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,11 +3,11 @@
 This file outlines future directions and open questions for studying the Sylvester square stack and its simulation code.
 
 1. **Identify the first point of divergence between strict and relaxed stacking.**
-   - 1a. Determine if any block eventually settles on more than two blocks of the same height, sliding across an extended plateau.
-   - 1b. Investigate whether a single block can experience this phenomenon more than once as it moves and falls.
+   - 1a. Determine if any square eventually settles on more than two squares of the same height, sliding across an extended plateau.
+   - 1b. Investigate whether a single square can experience this phenomenon more than once as it moves and falls.
 2. **Analyze the bottom boundary.**  Measure the total length of the intersection with the ground `y=0`.  Establish whether this length is finite or infinite and provide a decimal approximation if finite.
 3. **Study the region near `(1, \alpha)`.**  With \(\alpha\) denoting the length of the intersection with `y=1`, describe the local shape just to the right and below this point.  Is the boundary differentiable there?  What slope, if any, does it approach?
 4. **Review and refine the stacking algorithm.**  Confirm that the code matches the intended rules or update it accordingly.
-5. **Design a more efficient data structure.**  Consider a tree-based approach to compute block placements more quickly.
+5. **Design a more efficient data structure.**  Consider a tree-based approach to compute square placements more quickly.
 6. **Define the function `f(a)`.**  For each `a` in `[0,1]`, let `f(a)` be the horizontal length of the stack's cross section at height `y=a`.  Explore properties of this function, including monotonicity, differentiability, and behavior near `a=1`.
 7. **Create an interactive visualization.**  Develop a UI that allows zooming and panning.  The interface should request additional iterations as needed so users can explore fine details of the shape.


### PR DESCRIPTION
## Summary
- show sample stack images in README next to each algorithm description
- include example images in each algorithm's specification
- add render examples for Sylvester fill modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cd6805bc83249eed81e5bc12d7f2